### PR TITLE
Fix ERROR: Conanfile not found

### DIFF
--- a/src/cupcake/main.py
+++ b/src/cupcake/main.py
@@ -163,7 +163,7 @@ def pack_github(path):
         user, project, suffix = re.match(PATTERN_GITHUB_PATH, path).groups()
         if suffix is None:
             suffix = '/'
-        run(['git', 'clone', f'https://github.com/{user}/{project}', tmp])
+        run(['git', 'clone', '--recursive', f'https://github.com/{user}/{project}', tmp])
         yield tmp + suffix
 
 def update_dependency(metadata, group, name, f):


### PR DESCRIPTION
```
cupcake pack https://github.com/thejohnfreeman/project-template-cpp/tree/master/cupcake 
ERROR: Conanfile not found at /var/folders/dk/6fkgm_l10710rqwqj3nbhgyw0000gn/T/tmpsw2g8dex/cupcake/conanfile.py
```
    git clone https://github.com/thejohnfreeman/project-template-cpp /var/folders/dk/6fkgm_l10710rqwqj3nbhgyw0000gn/T/tmpwees959a
    Cloning into '/var/folders/dk/6fkgm_l10710rqwqj3nbhgyw0000gn/T/tmpwees959a'...
    remote: Enumerating objects: 2856, done.
    remote: Counting objects: 100% (948/948), done.
    remote: Compressing objects: 100% (480/480), done.
    remote: Total 2856 (delta 608), reused 739 (delta 421), pack-reused 1908
    Receiving objects: 100% (2856/2856), 384.86 KiB | 85.00 KiB/s, done.
    Resolving deltas: 100% (1603/1603), done.
    conan export /var/folders/dk/6fkgm_l10710rqwqj3nbhgyw0000gn/T/tmpwees959a/cupcake
    ERROR: Conanfile not found at /var/folders/dk/6fkgm_l10710rqwqj3nbhgyw0000gn/T/tmpwees959a/cupcake/conanfile.py
```